### PR TITLE
To eliminate a current error condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:trusty
 
 MAINTAINER Piotr Zduniak <piotr@zduniak.net>
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y nginx curl


### PR DESCRIPTION
Changing the Debian Frontend to noninteractive eliminates the [91mdebcon: unable to initialize frontend: Dialog... error which occurs during the build otherwise. I am running on Ubuntu 14.04 & implementing the OSS script.